### PR TITLE
[FEAT] Skip login if user id already stored

### DIFF
--- a/shopping_cart_app/lib/src/presentation/screens/app_start.dart
+++ b/shopping_cart_app/lib/src/presentation/screens/app_start.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:lottie/lottie.dart';
+import 'package:provider/provider.dart';
+import 'package:shopping_cart_app/src/presentation/presentation.dart';
 
 class AppStart extends StatefulWidget {
   const AppStart({super.key});
@@ -16,11 +18,16 @@ class _AppStartState extends State<AppStart> {
   void initState() {
     super.initState();
 
-    Timer(const Duration(seconds: 8), () {
-      GoRouter.of(context).pushReplacement('/login');
+    Timer(const Duration(seconds: 3), () {
+      final userController = context.read<UserController>();
+      var route = '/login';
+      if (userController.isLoggedIn) {
+        route = '/products/${userController.userId}';
+      }
+      GoRouter.of(context).pushReplacement(route);
     });
   }
-  
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/shopping_cart_app/lib/src/presentation/state/user_controller.dart
+++ b/shopping_cart_app/lib/src/presentation/state/user_controller.dart
@@ -12,27 +12,28 @@ class UserController with ChangeNotifier {
     required SharedPreferences preferences,
     required this.shoppingCartRepository,
   }) : _preferences = preferences {
-    _loggedIn = _preferences.getBool(PreferencesKeys.loggedIn) ?? false;
+    _userId = _preferences.getInt(PreferencesKeys.loggedIn);
   }
 
   final SharedPreferences _preferences;
   final HttpShoppingCartRepository shoppingCartRepository;
 
-  late bool _loggedIn;
+  int? _userId;
 
-  bool get isLoggedIn => _loggedIn;
+  bool get isLoggedIn => _userId != null;
+  int? get userId => _userId;
 
-  Future<void> logIn() async {
-    await _preferences.setBool(PreferencesKeys.loggedIn, true);
+  Future<void> logIn(int userId) async {
+    await _preferences.setInt(PreferencesKeys.loggedIn, userId);
 
-    _loggedIn = true;
+    _userId = userId;
     notifyListeners();
   }
 
   Future<void> logOut() async {
-    await _preferences.setBool(PreferencesKeys.loggedIn, false);
+    await _preferences.remove(PreferencesKeys.loggedIn);
 
-    _loggedIn = false;
+    _userId = null;
     notifyListeners();
   }
 
@@ -93,7 +94,7 @@ class UserController with ChangeNotifier {
 
       for (var user in users) {
         if (user.username == username && user.password == password) {
-          await logIn();
+        await logIn(user.id);
 
           return user;
         }


### PR DESCRIPTION
Saltea la pantalla de login si el usuario ya inició sesión:

- en lugar de guardar si el usuario está logeado con `true`/`false`, podés guardar el id del usuario que inició sesión.
- de esta forma si el valor no es nulo, quiere decir que el usuario inició sesión, entonces podríamos saltear la pantalla de login
- ahora podrías eliminar el id del usuario en la navegación y tomarlo directamente desde el `UserController`